### PR TITLE
update hunter link for issue #2290

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,8 @@ cable_configure_toolchain(DEFAULT cxx11)
 set(HUNTER_CONFIGURATION_TYPES Release CACHE STRING "Build type of Hunter packages")
 set(HUNTER_JOBS_NUMBER 6 CACHE STRING "Number of parallel builds used by Hunter")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.112.tar.gz"
-    SHA1 "4b894e1d5d203f0cc9a77431dbb1b486ab6f4430"
-    LOCAL
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.300.tar.gz"
+    SHA1 "1151d539465d9cdbc880ee30f794864aec11c448"
 )
 
 project(ethminer)


### PR DESCRIPTION
This PR is used to fix the issue error: downloading 'https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.7z' failed #2290
The original hunter is ruslo/hunter is not maintained. The link of boost included in it is unavailable now.

So, update the cpp_pm/hunter to fix the boost link issue.